### PR TITLE
pushing notebook for code snippets

### DIFF
--- a/meetings/relevant_snippets.ipynb
+++ b/meetings/relevant_snippets.ipynb
@@ -1,0 +1,136 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ee45ed45",
+   "metadata": {},
+   "source": [
+    "# A place to store useful, fun or just plain weird examples of code."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca3d94e7",
+   "metadata": {},
+   "source": [
+    "## exploring .mro(), \"method resolution order\"\n",
+    "\n",
+    "\"returns a list of types the class is derived from, in the order they are searched for methods\"\n",
+    "\n",
+    "using .mro() to print method resolution order of classes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c08d78c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class A: pass\n",
+    "class B(A): pass\n",
+    "class C(A): pass\n",
+    "class D(B, C): pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "364d3fbe",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[<class '__main__.D'>, <class '__main__.B'>, <class '__main__.C'>, <class '__main__.A'>, <class 'object'>]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(D.mro())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00c62bfc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[dict, object]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a = {'a': [1,2,3]}\n",
+    "# note how I can't do a.mro because only type(a) is a builtin\n",
+    "type(a).mro()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f954af10",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[pandas.core.frame.DataFrame,\n",
+       " pandas.core.generic.NDFrame,\n",
+       " pandas.core.base.PandasObject,\n",
+       " pandas.core.accessor.DirNamesMixin,\n",
+       " pandas.core.indexing.IndexingMixin,\n",
+       " pandas.core.arraylike.OpsMixin,\n",
+       " object]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "type(pd.DataFrame({'a': [1,2]})).mro()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce06fc3b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "materials-python-class",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
as promised pushing the notebook. 

The idea is that you/others can add examples they find useful. I wasn't sure about where it should live - breaks the nice order of the 'meetings' folder, and they're `md` files, so maybe doesn't belong in there. 

I also thought it didn't deserve it's own date, as the idea is to update this ad-hoc when needed with new example. Feel free to change it as you want!

For the .mro() example, I could have linked to where in Narwhals this is currently used, but as this branch isn't merged yet, I didn't think that made sense. 

https://github.com/narwhals-dev/narwhals/pull/2978/files, see `narwhals/_utils.py`
